### PR TITLE
Fix for Hackage 2.0

### DIFF
--- a/chrome/hackage.js
+++ b/chrome/hackage.js
@@ -1,12 +1,15 @@
 // Force include jquery:
 // (http://stackoverflow.com/questions/7474354/include-jquery-in-the-javascript-console)
 
+var versionRegex = /(\d+\.)+\d+$/;
+
 // Parse an entire page to find the array of Versions
 getVersionsFromPage = function(elem) {
   // Find the element
   var tr = elem.find('table > tbody > tr > th:contains("Version")').next();
   // Return all links to versions as an array of version numbers
-  return $.map(tr.children(), function(e) { return $(e).text(); });
+  return $.map(tr.children(), function(e) { return $(e).text(); })
+    .filter(function(v) { return versionRegex.exec(v); });
 }
 
 // Shortcut to add a nav link
@@ -120,7 +123,7 @@ if(contentsPath) {
   var noVersionPath = contentsPath.replace(/-(\d+\.)+\d+$/, "")
 
   var packageName = noVersionPath.split('/').reverse()[0]
-  var currentVersion = contentsPath.match(/(\d+\.)+\d+$/)[0]; // TODO: tidyup
+  var currentVersion = contentsPath.match(versionRegex)[0]; // TODO: tidyup
   var latestPackageUrl = noVersionPath; // Absolute or relative paths work.
 
   // Get list of package versions & add button when complete


### PR DESCRIPTION
On som contents pages on Hackage (e.g. [`transformers`'](http://hackage.haskell.org/package/transformers)) there is a link titled `(info)`:

![hackage-info-link](https://cloud.githubusercontent.com/assets/124073/5541832/b41e0e0c-8ade-11e4-97a0-9c3fa4239f3c.png)

The link text `(info)` is incorrectly recognized as a version number, causing the current documentation to be reported as outdated:

![hackage-fu-error](https://cloud.githubusercontent.com/assets/124073/5541878/6f6d454c-8adf-11e4-99fd-d3c435c7e8ef.png)

This pull request fixes this error.
