### PR TITLE
Add support for https hackage

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Hackage-Fu",
-  "version": "0.2.0.2",
+  "version": "0.2.0.3",
   "description": "Productivity Tools for HackageDB",
 
   "icons": {
@@ -14,11 +14,11 @@
   "content_scripts": [{
     "css": [ "main.css" ],
     "js": [ "jquery.min.js", "hackage.js" ],
-    "matches": [ "http://hackage.haskell.org/package*" ],
+    "matches": [ "*://hackage.haskell.org/package*" ],
     "run_at": "document_end"
   }],
 
-  "permissions": [ "tabs", "http://hackage.haskell.org/package*" ],
+  "permissions": [ "tabs", "*://hackage.haskell.org/package*" ],
 
   "manifest_version": 2
 }


### PR DESCRIPTION
Hello,

I've been using the extension on Chrome for a few months and I love it. Lately though, I've seen it increasingly not work at all from time to time, and finally had an epiphany this morning: it was https.

_Digression_: https://hackage.haskell.org tends to happen when coming from Google search results. I know that Google somewhat recently began preferring https results, and maybe this also has something to do with the new haskell.org, but anyway I suspect this must not be happening only to me - end of digression.

This PR adds support for the https-served hackage.haskell.org (noting that according to the docs, \* in the scheme part means either http or https but no other protocol). I've tested it by installing it as an unpacked extension and it works satisfactorily on https hackage in my Chrome 40.

I have, like most devs I guess, no prior experience with Chrome extensions, so let me know if anything looks off.
